### PR TITLE
[ZSS] IE flexbox fix

### DIFF
--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -23,6 +23,7 @@
 
 @mixin create-grid-row($gutter) {
     display: flex;
+    flex: 1 1 0;
     flex-wrap: wrap;
     margin-right: $gutter / -2;
     margin-left: $gutter / -2;


### PR DESCRIPTION
IE flexbox does not work unless this is added to the grid-row class. Other variations like flex: 1; or flex: 1 0 0 also work.